### PR TITLE
Overhaul styling and add TripForge personal projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>Johnathan Margheret - Product Manager</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Sora:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -25,10 +25,10 @@
     </ul>
     <div class="nav-icons">
       <a href="https://www.linkedin.com/in/johnathan-margheret-902886177" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" class="icon-link">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
       <a href="https://github.com/SpartanMods" target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" class="icon-link">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
       </a>
     </div>
   </nav>
@@ -36,43 +36,31 @@
 
 <main>
 
-  <!-- 01 / HERO -->
+  <!-- HERO -->
   <section id="hero" class="hero" aria-label="Introduction">
     <div class="hero-bg" aria-hidden="true">
       <div class="hero-grid"></div>
-      <span class="hero-deco">PM</span>
     </div>
-    <div class="hero-inner">
-      <div class="hero-content">
-        <p class="hero-eyebrow reveal-up">Johnathan Margheret</p>
-        <h1 class="hero-headline reveal-up" style="--delay:0.1s">
-          Product leader building<br>
-          <em>data and AI-powered</em><br>
-          products that translate<br>
-          complexity into value.
-        </h1>
-        <p class="hero-sub reveal-up" style="--delay:0.2s">
-          6+ years building products at the intersection of data, AI, and healthcare operations
-        </p>
-        <div class="hero-ctas reveal-up" style="--delay:0.3s">
-          <a href="#work" class="btn btn-primary">View My Work</a>
-          <a href="[RESUME_PDF_URL]" class="btn btn-outline" target="_blank" rel="noopener">Download Resume</a>
-        </div>
-      </div>
-      <p class="hero-footer reveal-up" style="--delay:0.45s">
-        <span style="font-family:var(--font-mono);font-size:0.7rem;letter-spacing:0.1em">Product Manager</span>
-        <span class="hero-footer-sep" aria-hidden="true">/</span>
-        <span style="font-family:var(--font-mono);font-size:0.7rem;letter-spacing:0.1em">Data &amp; AI Products</span>
+    <div class="hero-content">
+      <p class="hero-name reveal-up">Johnathan Margheret</p>
+      <h1 class="hero-headline reveal-up" style="--delay:0.08s">
+        Product leader building data and AI-powered products that translate complexity into value.
+      </h1>
+      <p class="hero-sub reveal-up" style="--delay:0.16s">
+        6+ years building products at the intersection of data, AI, and healthcare operations
       </p>
+      <div class="hero-ctas reveal-up" style="--delay:0.24s">
+        <a href="#work" class="btn btn-primary">View My Work</a>
+        <a href="[RESUME_PDF_URL]" class="btn btn-outline" target="_blank" rel="noopener">Download Resume</a>
+      </div>
     </div>
   </section>
 
-  <!-- 02 / ABOUT -->
+  <!-- ABOUT -->
   <section id="about" class="section" aria-labelledby="about-heading">
-    <div class="section-label">
-      <span class="label-num">02</span>
-      <span class="label-rule" aria-hidden="true"></span>
-      <h2 id="about-heading" class="label-text">About</h2>
+    <div class="section-header">
+      <span class="section-tag">02 / About</span>
+      <h2 id="about-heading">Background</h2>
     </div>
     <div class="about-grid">
       <div class="about-bio reveal-up">
@@ -117,28 +105,22 @@
     </div>
   </section>
 
-  <!-- 03 / WORK -->
+  <!-- WORK -->
   <section id="work" class="section" aria-labelledby="work-heading">
-    <div class="section-label">
-      <span class="label-num">03</span>
-      <span class="label-rule" aria-hidden="true"></span>
-      <h2 id="work-heading" class="label-text">Work Experience</h2>
+    <div class="section-header">
+      <span class="section-tag">03 / Experience</span>
+      <h2 id="work-heading">Work Experience</h2>
     </div>
     <div class="timeline">
       <article class="role-card reveal-up">
-        <div class="role-head">
-          <div class="role-info">
-            <h3 class="role-title">Data Product Owner / PM</h3>
-            <p class="role-company">TEAM Services Group</p>
-            <p class="role-meta">
-              2024 &ndash; Present
-              <span class="meta-sep">/</span>National in-home healthcare
-              <span class="meta-sep">/</span>15+ brands
-              <span class="meta-sep">/</span>50 states
-            </p>
-          </div>
-          <span class="role-idx" aria-hidden="true">01</span>
-        </div>
+        <h3 class="role-title">Data Product Owner / PM</h3>
+        <p class="role-company">TEAM Services Group</p>
+        <p class="role-meta">
+          2024 &ndash; Present
+          <span class="meta-sep">/</span>National in-home healthcare
+          <span class="meta-sep">/</span>15+ brands
+          <span class="meta-sep">/</span>50 states
+        </p>
         <ul class="role-highlights">
           <li>Built AI document parsing app saving $300K per year</li>
           <li>Developed AI-powered lead generation tool driving $1.5M in pipeline</li>
@@ -165,14 +147,9 @@
       <!-- PRIOR ROLE: [PRIOR_ROLE_COMPANY] | [Title] | [Dates] -->
       <!--
       <article class="role-card reveal-up">
-        <div class="role-head">
-          <div class="role-info">
-            <h3 class="role-title">[Title]</h3>
-            <p class="role-company">[PRIOR_ROLE_COMPANY]</p>
-            <p class="role-meta">[Dates]</p>
-          </div>
-          <span class="role-idx" aria-hidden="true">02</span>
-        </div>
+        <h3 class="role-title">[Title]</h3>
+        <p class="role-company">[PRIOR_ROLE_COMPANY]</p>
+        <p class="role-meta">[Dates]</p>
         <ul class="role-highlights">
           <li>[Key highlight]</li>
         </ul>
@@ -181,12 +158,11 @@
     </div>
   </section>
 
-  <!-- 04 / PROJECTS -->
+  <!-- WORK PROJECTS -->
   <section id="projects" class="section" aria-labelledby="projects-heading">
-    <div class="section-label">
-      <span class="label-num">04</span>
-      <span class="label-rule" aria-hidden="true"></span>
-      <h2 id="projects-heading" class="label-text">Featured Projects</h2>
+    <div class="section-header">
+      <span class="section-tag">04 / Work Projects</span>
+      <h2 id="projects-heading">Featured Projects</h2>
     </div>
     <div class="projects-grid">
 
@@ -239,16 +215,59 @@
     </div>
   </section>
 
-  <!-- 05 / SKILLS -->
+  <!-- PERSONAL PROJECTS -->
+  <section id="personal" class="section" aria-labelledby="personal-heading">
+    <div class="section-header">
+      <span class="section-tag">05 / Personal</span>
+      <h2 id="personal-heading">Personal Projects</h2>
+    </div>
+
+    <article class="personal-project-card reveal-up">
+      <div class="pp-header">
+        <div class="pp-meta">
+          <span class="pp-status">In Development</span>
+          <h3 class="pp-title">TripForge</h3>
+          <p class="pp-tagline">Collaborative trip planning, from idea to itinerary</p>
+        </div>
+        <a href="https://github.com/SpartanMods/TripForge" target="_blank" rel="noopener noreferrer" class="pp-link" aria-label="TripForge on GitHub">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+          View on GitHub
+        </a>
+      </div>
+      <p class="pp-desc">
+        A web app for groups who want to plan trips together without the back-and-forth. Enter your budget,
+        vibe, departure city, and dates, and get AI-powered destination suggestions with estimated costs.
+        From there, collaborators search real flights, hotels, and activities, vote on options, and watch a
+        shared budget tracker update in real time as the itinerary comes together.
+      </p>
+      <div class="pp-features">
+        <span>AI destination suggestions</span>
+        <span>Real-time collaborative voting</span>
+        <span>Flight and hotel search</span>
+        <span>Per-person budget tracking</span>
+        <span>Multi-city itinerary support</span>
+        <span>Live activity feed</span>
+      </div>
+      <div class="pp-tags">
+        <span class="tag">React 19</span>
+        <span class="tag">TypeScript</span>
+        <span class="tag">Tailwind CSS</span>
+        <span class="tag">Supabase</span>
+        <span class="tag">Claude API</span>
+        <span class="tag">Vercel</span>
+      </div>
+    </article>
+  </section>
+
+  <!-- SKILLS -->
   <section id="skills" class="section" aria-labelledby="skills-heading">
-    <div class="section-label">
-      <span class="label-num">05</span>
-      <span class="label-rule" aria-hidden="true"></span>
-      <h2 id="skills-heading" class="label-text">Skills &amp; Stack</h2>
+    <div class="section-header">
+      <span class="section-tag">06 / Stack</span>
+      <h2 id="skills-heading">Skills &amp; Stack</h2>
     </div>
     <div class="skills-grid">
       <div class="skill-group reveal-up">
-        <h3 class="skill-group-label">PRODUCT</h3>
+        <h3 class="skill-group-label">Product</h3>
         <div class="skill-tags">
           <span class="tag">Product Strategy</span>
           <span class="tag">Roadmapping</span>
@@ -262,8 +281,8 @@
           <span class="tag">Confluence</span>
         </div>
       </div>
-      <div class="skill-group reveal-up" style="--delay:0.1s">
-        <h3 class="skill-group-label">DATA &amp; ENGINEERING</h3>
+      <div class="skill-group reveal-up" style="--delay:0.08s">
+        <h3 class="skill-group-label">Data &amp; Engineering</h3>
         <div class="skill-tags">
           <span class="tag">Snowflake</span>
           <span class="tag">dbt</span>
@@ -276,8 +295,8 @@
           <span class="tag">GitHub</span>
         </div>
       </div>
-      <div class="skill-group reveal-up" style="--delay:0.2s">
-        <h3 class="skill-group-label">AI &amp; AUTOMATION</h3>
+      <div class="skill-group reveal-up" style="--delay:0.16s">
+        <h3 class="skill-group-label">AI &amp; Automation</h3>
         <div class="skill-tags">
           <span class="tag">LLM Integration</span>
           <span class="tag">Anthropic API</span>
@@ -286,8 +305,8 @@
           <span class="tag">Claude Code</span>
         </div>
       </div>
-      <div class="skill-group reveal-up" style="--delay:0.3s">
-        <h3 class="skill-group-label">DESIGN &amp; COMPLIANCE</h3>
+      <div class="skill-group reveal-up" style="--delay:0.24s">
+        <h3 class="skill-group-label">Design &amp; Compliance</h3>
         <div class="skill-tags">
           <span class="tag">Figma</span>
           <span class="tag">Wireframing</span>
@@ -299,90 +318,21 @@
     </div>
   </section>
 
-  <!-- TICKER -->
-  <div class="ticker-wrap" aria-hidden="true">
-    <div class="ticker">
-      <span class="ticker-item">Snowflake</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">dbt</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Dagster</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Power BI</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Streamlit</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">AWS</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Python</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">SQL</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">LLM Integration</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Anthropic API</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Prompt Engineering</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Figma</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">HIPAA Compliance</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Roadmapping</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">OKR Frameworks</span>
-      <span class="ticker-item accent">*</span>
-      <!-- duplicate for seamless loop -->
-      <span class="ticker-item">Snowflake</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">dbt</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Dagster</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Power BI</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Streamlit</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">AWS</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Python</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">SQL</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">LLM Integration</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Anthropic API</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Prompt Engineering</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Figma</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">HIPAA Compliance</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">Roadmapping</span>
-      <span class="ticker-item accent">*</span>
-      <span class="ticker-item">OKR Frameworks</span>
-      <span class="ticker-item accent">*</span>
-    </div>
-  </div>
-
-  <!-- 06 / CONTACT -->
+  <!-- CONTACT -->
   <section id="contact" class="section contact-section" aria-labelledby="contact-heading">
     <div class="contact-inner">
       <div class="contact-text reveal-up">
-        <h2 id="contact-heading" class="contact-heading">
-          Let's build<br><em>something.</em>
-        </h2>
+        <h2 id="contact-heading" class="contact-heading">Let's build something.</h2>
         <p class="contact-sub">Open to product roles in AI, data, analytics, and enterprise platforms.</p>
         <p class="contact-location">Denver, CO &nbsp;/&nbsp; Remote-friendly</p>
       </div>
-      <div class="contact-actions reveal-up" style="--delay:0.12s">
+      <div class="contact-actions reveal-up" style="--delay:0.1s">
         <a href="https://www.linkedin.com/in/johnathan-margheret-902886177" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
           Connect on LinkedIn
         </a>
         <a href="https://github.com/SpartanMods" target="_blank" rel="noopener noreferrer" class="btn btn-outline">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
           GitHub
         </a>
         <a href="mailto:jcmargheret@live.com" class="btn btn-ghost">jcmargheret@live.com</a>
@@ -395,7 +345,7 @@
 <footer class="site-footer">
   <p class="footer-text">
     <span>&copy; 2026 Johnathan Margheret</span>
-    <span class="footer-sep" aria-hidden="true">/</span>
+    <span class="footer-sep">/</span>
     <span>Built with intention.</span>
   </p>
 </footer>

--- a/style.css
+++ b/style.css
@@ -1,26 +1,24 @@
 :root {
   --bg: #0D0F14;
   --bg-card: #131620;
-  --bg-card-hover: #181c28;
+  --bg-card-hover: #171c28;
   --text: #E8E4DC;
   --text-muted: #8B8680;
   --text-dim: #4E4C48;
   --accent: #F5A623;
-  --accent-dim: rgba(245,166,35,0.12);
-  --accent-glow: rgba(245,166,35,0.25);
+  --accent-dim: rgba(245,166,35,0.1);
   --border: rgba(232,228,220,0.08);
-  --border-hover: rgba(245,166,35,0.35);
-  --font-display: 'Playfair Display', Georgia, serif;
-  --font-body: 'Sora', system-ui, sans-serif;
-  --font-mono: 'IBM Plex Mono', 'Courier New', monospace;
-  --max-w: 1200px;
-  --gap: 130px;
-  --nav-h: 64px;
-  --r: 3px;
-  --ease: 0.2s ease;
+  --border-hover: rgba(245,166,35,0.28);
+  --font: 'Roboto', system-ui, sans-serif;
+  --font-mono: 'Roboto Mono', 'Courier New', monospace;
+  --max-w: 1160px;
+  --gap: 110px;
+  --nav-h: 60px;
+  --r: 4px;
+  --t: 0.18s ease;
 }
 
-*,*::before,*::after { box-sizing: border-box; margin: 0; padding: 0; }
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 html {
   scroll-behavior: smooth;
@@ -32,8 +30,9 @@ html {
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: var(--font-body);
-  line-height: 1.6;
+  font-family: var(--font);
+  font-weight: 400;
+  line-height: 1.65;
   overflow-x: hidden;
 }
 
@@ -43,16 +42,15 @@ ul { list-style: none; }
 
 ::-webkit-scrollbar { width: 3px; }
 ::-webkit-scrollbar-track { background: var(--bg); }
-::-webkit-scrollbar-thumb { background: var(--accent-dim); border-radius: 2px; }
+::-webkit-scrollbar-thumb { background: var(--accent-dim); }
 ::-webkit-scrollbar-thumb:hover { background: var(--accent); }
 
 /* Progress bar */
 .progress-bar {
   position: fixed; top: 0; left: 0; z-index: 200;
   width: var(--prog, 0%); height: 2px;
-  background: var(--accent);
+  background: var(--accent); pointer-events: none;
   transition: width 0.08s linear;
-  pointer-events: none;
 }
 
 /* Nav */
@@ -60,415 +58,305 @@ ul { list-style: none; }
   position: fixed; top: 0; left: 0; right: 0;
   height: var(--nav-h); z-index: 100;
   border-bottom: 1px solid transparent;
-  transition: background var(--ease), border-color var(--ease);
+  transition: background var(--t), border-color var(--t);
 }
-
 .site-header.scrolled {
-  background: rgba(13,15,20,0.9);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  background: rgba(13,15,20,0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-color: var(--border);
 }
-
 .nav {
   max-width: calc(var(--max-w) + 4rem);
   margin: 0 auto; padding: 0 2rem;
   height: 100%; display: flex; align-items: center; gap: 2rem;
 }
-
 .nav-brand {
-  font-family: var(--font-display);
-  font-size: 1rem; font-weight: 700;
-  color: var(--accent); letter-spacing: 0.06em;
-  padding: 0.25em 0.6em;
-  border: 1px solid var(--accent-dim);
-  margin-right: auto; line-height: 1.4;
-  transition: border-color var(--ease), background var(--ease);
+  font-size: 0.875rem; font-weight: 700;
+  color: var(--accent); margin-right: auto;
+  letter-spacing: 0.05em;
 }
-.nav-brand:hover { border-color: var(--accent); background: var(--accent-dim); }
-
-.nav-links {
-  display: flex; gap: 2.5rem; align-items: center;
-}
+.nav-links { display: flex; gap: 2rem; }
 .nav-links a {
-  font-size: 0.72rem; font-weight: 500;
-  letter-spacing: 0.14em; text-transform: uppercase;
-  color: var(--text-muted);
-  position: relative;
-  transition: color var(--ease);
-}
-.nav-links a::after {
-  content: ''; position: absolute; bottom: -4px; left: 0;
-  width: 0; height: 1px; background: var(--accent);
-  transition: width var(--ease);
+  font-size: 0.82rem; color: var(--text-muted);
+  font-weight: 400; transition: color var(--t);
 }
 .nav-links a:hover { color: var(--text); }
-.nav-links a:hover::after { width: 100%; }
-
-.nav-icons { display: flex; gap: 0.6rem; }
-
+.nav-icons { display: flex; gap: 0.5rem; }
 .icon-link {
   display: flex; align-items: center; justify-content: center;
-  width: 34px; height: 34px;
+  width: 32px; height: 32px;
   color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--r);
-  transition: color var(--ease), border-color var(--ease);
+  transition: color var(--t), border-color var(--t);
 }
 .icon-link:hover { color: var(--text); border-color: var(--border-hover); }
 
 /* Hero */
 .hero {
   position: relative; min-height: 100dvh;
-  overflow: hidden;
+  display: flex; align-items: center; overflow: hidden;
 }
-
 .hero-bg {
-  position: absolute; inset: 0; pointer-events: none; overflow: hidden;
+  position: absolute; inset: 0; pointer-events: none;
 }
-
 .hero-grid {
   position: absolute; inset: 0;
   background-image:
-    linear-gradient(rgba(245,166,35,0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(245,166,35,0.04) 1px, transparent 1px);
-  background-size: 68px 68px;
-  animation: gridDrift 28s ease-in-out infinite;
+    linear-gradient(rgba(245,166,35,0.028) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(245,166,35,0.028) 1px, transparent 1px);
+  background-size: 72px 72px;
 }
-@keyframes gridDrift {
-  0%,100% { transform: translate(0,0); }
-  40%      { transform: translate(-22px,-16px); }
-  70%      { transform: translate(12px,-28px); }
-}
-
-.hero-deco {
-  position: absolute; bottom: -0.08em; right: -0.04em;
-  font-family: var(--font-display);
-  font-size: clamp(180px, 26vw, 380px);
-  font-weight: 900;
-  color: transparent;
-  -webkit-text-stroke: 1px rgba(245,166,35,0.055);
-  line-height: 1; user-select: none;
-}
-
-.hero-inner {
+.hero-content {
   position: relative; z-index: 1;
-  min-height: 100dvh;
-  display: flex; flex-direction: column; justify-content: space-between;
-  padding: calc(var(--nav-h) + 5rem) 2rem 3.5rem;
   max-width: calc(var(--max-w) + 4rem);
-  margin: 0 auto;
+  width: 100%; margin: 0 auto;
+  padding: calc(var(--nav-h) + 5rem) 2rem 4rem;
 }
-
-.hero-eyebrow {
+.hero-name {
+  font-size: 0.78rem; font-weight: 500;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--text-dim); margin-bottom: 1.25rem;
   font-family: var(--font-mono);
-  font-size: 0.72rem; letter-spacing: 0.22em;
-  text-transform: uppercase; color: var(--accent);
-  margin-bottom: 1.5rem;
 }
-
 .hero-headline {
-  font-family: var(--font-display);
-  font-size: clamp(2.5rem, 5.8vw, 5.2rem);
-  font-weight: 700; line-height: 1.1;
-  letter-spacing: -0.025em;
-  margin-bottom: 1.5rem; max-width: 14em;
+  font-size: clamp(2.1rem, 4.8vw, 4.2rem);
+  font-weight: 700; line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin-bottom: 1.25rem; max-width: 18em;
 }
-.hero-headline em {
-  font-style: italic; color: var(--accent); font-weight: 400;
-}
-
 .hero-sub {
-  font-size: clamp(0.9rem, 1.4vw, 1.05rem);
-  color: var(--text-muted); max-width: 52ch;
-  margin-bottom: 2.5rem; line-height: 1.75;
+  font-size: 1rem; color: var(--text-muted);
+  max-width: 48ch; margin-bottom: 2.25rem;
+  line-height: 1.75; font-weight: 300;
 }
-
-.hero-ctas { display: flex; gap: 1rem; flex-wrap: wrap; }
-
-.hero-footer {
-  display: flex; align-items: center; gap: 0.75rem;
-  font-family: var(--font-mono); font-size: 0.7rem;
-  letter-spacing: 0.1em; color: var(--text-dim);
-}
-.hero-footer-sep { color: var(--accent); }
+.hero-ctas { display: flex; gap: 0.85rem; flex-wrap: wrap; }
 
 /* Buttons */
 .btn {
-  display: inline-flex; align-items: center; gap: 0.45rem;
-  padding: 0.7em 1.6em;
-  font-family: var(--font-body); font-size: 0.875rem; font-weight: 500;
-  letter-spacing: 0.03em; border-radius: var(--r);
-  border: 1px solid transparent;
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  padding: 0.65em 1.5em;
+  font-family: var(--font); font-size: 0.875rem; font-weight: 500;
+  border-radius: var(--r); border: 1px solid transparent;
   cursor: pointer; white-space: nowrap;
-  transition: background var(--ease), color var(--ease), border-color var(--ease);
+  transition: background var(--t), color var(--t), border-color var(--t);
 }
-.btn-primary { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+.btn-primary { background: var(--accent); color: #0D0F14; border-color: var(--accent); }
 .btn-primary:hover { background: #e8980f; border-color: #e8980f; }
 .btn-outline { background: transparent; color: var(--text); border-color: var(--border); }
 .btn-outline:hover { border-color: var(--border-hover); color: var(--accent); }
 .btn-ghost { background: transparent; color: var(--text-muted); }
 .btn-ghost:hover { color: var(--text); }
-.btn-lg { padding: 0.85em 2.1em; font-size: 0.95rem; }
+.btn-lg { padding: 0.8em 2em; font-size: 0.95rem; }
 
-/* Section layout */
+/* Sections */
 .section {
   padding: var(--gap) 2rem;
   max-width: calc(var(--max-w) + 4rem);
   margin: 0 auto; width: 100%;
 }
-
-.section-label {
-  display: flex; align-items: center; gap: 1rem;
-  margin-bottom: 3.5rem;
+.section-header { margin-bottom: 2.75rem; }
+.section-tag {
+  font-family: var(--font-mono); font-size: 0.68rem;
+  color: var(--accent); letter-spacing: 0.08em;
+  margin-bottom: 0.5rem; display: block;
 }
-.label-num {
-  font-family: var(--font-mono); font-size: 0.65rem;
-  color: var(--accent); letter-spacing: 0.18em;
-}
-.label-rule {
-  width: 2.5rem; height: 1px; background: var(--border);
-}
-.label-text {
-  font-family: var(--font-mono); font-size: 0.7rem;
-  letter-spacing: 0.16em; text-transform: uppercase;
-  color: var(--text-muted); font-weight: 400;
+.section-header h2 {
+  font-size: clamp(1.35rem, 2.2vw, 1.65rem);
+  font-weight: 700; letter-spacing: -0.01em;
 }
 
 /* About */
 .about-grid {
-  display: grid; grid-template-columns: 1.45fr 1fr;
+  display: grid; grid-template-columns: 1.4fr 1fr;
   gap: 5rem; align-items: start;
 }
-
 .about-bio h2 {
-  font-family: var(--font-display);
-  font-size: clamp(1.75rem, 2.8vw, 2.6rem);
-  font-weight: 700; letter-spacing: -0.02em;
-  line-height: 1.2; margin-bottom: 1.5rem;
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  font-weight: 700; margin-bottom: 1.25rem; letter-spacing: -0.01em;
 }
-
 .bio-text {
-  font-size: 1rem; line-height: 1.85;
-  color: var(--text-muted); max-width: 58ch;
+  font-size: 1rem; line-height: 1.8;
+  color: var(--text-muted); max-width: 56ch; font-weight: 300;
 }
-
 .stats-grid {
   display: grid; grid-template-columns: 1fr 1fr;
-  gap: 1px; background: var(--border);
-  border: 1px solid var(--border);
+  gap: 1px; background: var(--border); border: 1px solid var(--border);
 }
-
 .stat-card {
-  background: var(--bg-card);
-  padding: 1.4rem 1.2rem;
+  background: var(--bg-card); padding: 1.35rem 1.2rem;
   display: flex; flex-direction: column; gap: 0.25rem;
-  position: relative; overflow: hidden;
-  transition: background var(--ease);
+  transition: background var(--t);
 }
-.stat-card::before {
-  content: ''; position: absolute;
-  top: 0; left: 0; right: 0; height: 2px;
-  background: var(--accent);
-  transform: scaleX(0); transform-origin: left;
-  transition: transform 0.55s ease;
-}
-.stat-card.lit::before { transform: scaleX(1); }
 .stat-card:hover { background: var(--bg-card-hover); }
-
 .stat-num {
-  font-family: var(--font-display);
-  font-size: 1.85rem; font-weight: 700;
+  font-size: 1.75rem; font-weight: 700;
   color: var(--accent); line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 .stat-label {
   font-family: var(--font-mono); font-size: 0.62rem;
-  letter-spacing: 0.1em; text-transform: uppercase;
-  color: var(--text); margin-top: 0.25rem;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--text); margin-top: 0.2rem; font-weight: 500;
 }
-.stat-desc {
-  font-size: 0.76rem; color: var(--text-dim); line-height: 1.45;
-}
+.stat-desc { font-size: 0.76rem; color: var(--text-dim); line-height: 1.4; }
 
 /* Work */
 .timeline { display: flex; flex-direction: column; gap: 1px; background: var(--border); }
-
 .role-card {
-  background: var(--bg-card);
-  padding: 2.5rem;
-  border-left: 3px solid transparent;
-  transition: border-color var(--ease), background var(--ease);
+  background: var(--bg-card); padding: 2.25rem;
+  border-left: 2px solid transparent;
+  transition: border-color var(--t), background var(--t);
 }
 .role-card:hover { border-color: var(--accent); background: var(--bg-card-hover); }
-
-.role-head {
-  display: flex; justify-content: space-between; align-items: flex-start;
-  margin-bottom: 1.75rem;
-}
-.role-title {
-  font-family: var(--font-display);
-  font-size: 1.45rem; font-weight: 700;
-  letter-spacing: -0.01em; margin-bottom: 0.3rem;
-}
-.role-company { font-size: 0.9rem; color: var(--accent); font-weight: 500; margin-bottom: 0.4rem; }
+.role-title { font-size: 1.2rem; font-weight: 700; margin-bottom: 0.25rem; }
+.role-company { font-size: 0.875rem; color: var(--accent); font-weight: 500; margin-bottom: 0.35rem; }
 .role-meta {
   font-family: var(--font-mono); font-size: 0.67rem;
-  color: var(--text-dim); letter-spacing: 0.05em;
+  color: var(--text-dim); margin-bottom: 1.5rem;
 }
-.meta-sep { color: var(--accent); margin: 0 0.4em; }
-
-.role-idx {
-  font-family: var(--font-display); font-size: 3.2rem;
-  font-weight: 900; color: transparent;
-  -webkit-text-stroke: 1px rgba(232,228,220,0.07);
-  line-height: 1; user-select: none;
-  transition: -webkit-text-stroke-color var(--ease);
-}
-.role-card:hover .role-idx { -webkit-text-stroke-color: rgba(245,166,35,0.18); }
-
-.role-highlights { display: flex; flex-direction: column; gap: 0.55rem; margin-bottom: 1.75rem; }
+.meta-sep { color: var(--accent); margin: 0 0.35em; }
+.role-highlights { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1.5rem; }
 .role-highlights li {
   font-size: 0.875rem; color: var(--text-muted);
-  padding-left: 1.2em; position: relative; line-height: 1.6;
+  padding-left: 1.1em; position: relative; line-height: 1.55;
 }
 .role-highlights li::before {
   content: '/'; position: absolute; left: 0;
-  color: var(--accent); font-family: var(--font-mono); font-size: 0.78rem;
+  color: var(--accent); font-family: var(--font-mono);
 }
-
-.role-tags { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.role-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
 
 /* Tags */
 .tag {
-  display: inline-block;
-  font-family: var(--font-mono); font-size: 0.68rem;
-  letter-spacing: 0.06em; padding: 0.28em 0.7em;
+  display: inline-block; font-family: var(--font-mono); font-size: 0.67rem;
+  letter-spacing: 0.04em; padding: 0.27em 0.7em;
   border: 1px solid var(--border); border-radius: 2px;
-  color: var(--text-dim); background: transparent;
-  transition: border-color var(--ease), color var(--ease);
+  color: var(--text-dim);
+  transition: border-color var(--t), color var(--t);
 }
 .tag:hover { border-color: var(--border-hover); color: var(--text); }
 
-/* Projects */
+/* Work projects */
 .projects-grid {
   display: grid; grid-template-columns: 1fr 1fr;
   gap: 1px; background: var(--border);
 }
-
 .project-card {
-  background: var(--bg-card);
-  padding: 2rem; display: flex; flex-direction: column; gap: 0.7rem;
-  border-left: 3px solid transparent;
-  transition: border-color var(--ease), background var(--ease);
+  background: var(--bg-card); padding: 1.75rem;
+  display: flex; flex-direction: column; gap: 0.65rem;
+  border-left: 2px solid transparent;
+  transition: border-color var(--t), background var(--t);
 }
 .project-card:hover { border-color: var(--accent); background: var(--bg-card-hover); }
-
 .proj-idx {
-  font-family: var(--font-mono); font-size: 0.62rem;
-  color: var(--accent); letter-spacing: 0.16em;
+  font-family: var(--font-mono); font-size: 0.6rem;
+  color: var(--text-dim); letter-spacing: 0.12em;
 }
-.proj-title {
-  font-family: var(--font-display); font-size: 1.25rem;
-  font-weight: 700; letter-spacing: -0.01em;
-}
-.proj-desc { font-size: 0.875rem; color: var(--text-muted); line-height: 1.65; flex: 1; }
+.proj-title { font-size: 1.1rem; font-weight: 700; }
+.proj-desc { font-size: 0.875rem; color: var(--text-muted); line-height: 1.6; flex: 1; }
 .proj-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-.proj-link {
-  display: inline-flex; align-items: center; gap: 0.4em;
-  font-family: var(--font-mono); font-size: 0.68rem;
-  letter-spacing: 0.1em; color: var(--text-dim);
-  margin-top: 0.2rem; align-self: flex-start;
-  transition: color var(--ease);
+
+/* Personal project card */
+.personal-project-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  padding: 2.5rem;
+  transition: background var(--t), border-color var(--t);
 }
-.proj-link:hover { color: var(--accent); }
+.personal-project-card:hover { background: var(--bg-card-hover); }
+.pp-header {
+  display: flex; justify-content: space-between;
+  align-items: flex-start; gap: 2rem; margin-bottom: 1.25rem;
+}
+.pp-meta { display: flex; flex-direction: column; gap: 0.2rem; }
+.pp-status {
+  display: inline-block; font-family: var(--font-mono); font-size: 0.62rem;
+  letter-spacing: 0.08em; padding: 0.2em 0.65em;
+  border: 1px solid var(--accent-dim);
+  color: var(--accent); border-radius: 2px; margin-bottom: 0.5rem;
+  width: fit-content;
+}
+.pp-title { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.01em; }
+.pp-tagline { font-size: 0.875rem; color: var(--text-muted); margin-top: 0.15rem; }
+.pp-link {
+  display: inline-flex; align-items: center; gap: 0.4em; flex-shrink: 0;
+  font-family: var(--font-mono); font-size: 0.7rem; letter-spacing: 0.06em;
+  color: var(--text-muted); padding: 0.5em 1em;
+  border: 1px solid var(--border); border-radius: var(--r);
+  transition: color var(--t), border-color var(--t);
+}
+.pp-link:hover { color: var(--accent); border-color: var(--border-hover); }
+.pp-desc {
+  font-size: 0.95rem; color: var(--text-muted);
+  line-height: 1.75; max-width: 68ch;
+  margin-bottom: 1.5rem; font-weight: 300;
+}
+.pp-features {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.5rem 1rem; margin-bottom: 1.5rem;
+}
+.pp-features span {
+  font-size: 0.82rem; color: var(--text-muted);
+  display: flex; align-items: center; gap: 0.5rem;
+}
+.pp-features span::before {
+  content: ''; width: 4px; height: 4px; border-radius: 50%;
+  background: var(--accent); flex-shrink: 0;
+}
+.pp-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
 
 /* Skills */
-.skills-grid {
-  display: grid; grid-template-columns: 1fr 1fr;
-  gap: 3rem 5rem;
-}
+.skills-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 2.5rem 5rem; }
 .skill-group-label {
-  font-family: var(--font-mono); font-size: 0.62rem;
-  letter-spacing: 0.2em; color: var(--accent);
-  margin-bottom: 1rem; font-weight: 400;
+  font-family: var(--font-mono); font-size: 0.63rem;
+  letter-spacing: 0.12em; color: var(--text-dim);
+  margin-bottom: 0.85rem; font-weight: 400; text-transform: uppercase;
 }
-.skill-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-
-/* Ticker */
-.ticker-wrap {
-  overflow: hidden;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  padding: 0.85rem 0;
-  background: var(--bg-card);
-}
-.ticker {
-  display: flex; gap: 2rem;
-  width: max-content;
-  animation: tickerRoll 45s linear infinite;
-}
-.ticker:hover { animation-play-state: paused; }
-.ticker-item {
-  font-family: var(--font-mono); font-size: 0.68rem;
-  letter-spacing: 0.14em; text-transform: uppercase;
-  color: var(--text-dim); white-space: nowrap;
-}
-.ticker-item.accent { color: var(--accent); }
-@keyframes tickerRoll {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-50%); }
-}
+.skill-tags { display: flex; flex-wrap: wrap; gap: 0.45rem; }
 
 /* Contact */
 .contact-section { padding-top: var(--gap); padding-bottom: var(--gap); }
-
 .contact-inner {
   display: grid; grid-template-columns: 1fr auto;
   gap: 4rem; align-items: center;
   border-top: 1px solid var(--border); padding-top: 4rem;
 }
-
 .contact-heading {
-  font-family: var(--font-display);
-  font-size: clamp(2.4rem, 4.8vw, 4.2rem);
-  font-weight: 700; letter-spacing: -0.03em;
-  line-height: 1.1; margin-bottom: 1rem;
+  font-size: clamp(2rem, 3.8vw, 3.25rem);
+  font-weight: 700; letter-spacing: -0.02em;
+  line-height: 1.15; margin-bottom: 0.85rem;
 }
-.contact-heading em { font-style: italic; color: var(--accent); font-weight: 400; }
-
 .contact-sub {
   font-size: 0.95rem; color: var(--text-muted);
-  max-width: 40ch; margin-bottom: 0.75rem; line-height: 1.7;
+  max-width: 38ch; margin-bottom: 0.65rem;
+  line-height: 1.7; font-weight: 300;
 }
 .contact-location {
   font-family: var(--font-mono); font-size: 0.7rem;
-  letter-spacing: 0.08em; color: var(--text-dim);
+  letter-spacing: 0.06em; color: var(--text-dim);
 }
-
-.contact-actions {
-  display: flex; flex-direction: column;
-  gap: 0.7rem; min-width: 210px;
-}
+.contact-actions { display: flex; flex-direction: column; gap: 0.65rem; min-width: 200px; }
 
 /* Footer */
 .site-footer {
   border-top: 1px solid var(--border);
   padding: 1.75rem 2rem;
-  max-width: calc(var(--max-w) + 4rem);
-  margin: 0 auto;
+  max-width: calc(var(--max-w) + 4rem); margin: 0 auto;
 }
 .footer-text {
-  display: flex; align-items: center; gap: 1rem;
-  font-family: var(--font-mono); font-size: 0.68rem;
-  color: var(--text-dim); letter-spacing: 0.08em;
+  display: flex; align-items: center; gap: 0.75rem;
+  font-family: var(--font-mono); font-size: 0.67rem;
+  color: var(--text-dim); letter-spacing: 0.05em;
 }
 .footer-sep { color: var(--accent); }
 
 /* Scroll reveal */
 .reveal-up {
-  opacity: 0; transform: translateY(22px);
+  opacity: 0; transform: translateY(16px);
   transition:
-    opacity 0.6s cubic-bezier(0.22,1,0.36,1),
-    transform 0.6s cubic-bezier(0.22,1,0.36,1);
+    opacity 0.5s cubic-bezier(0.22,1,0.36,1),
+    transform 0.5s cubic-bezier(0.22,1,0.36,1);
   transition-delay: var(--delay, 0s);
 }
 .reveal-up.in-view { opacity: 1; transform: translateY(0); }
@@ -476,36 +364,32 @@ ul { list-style: none; }
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .reveal-up { opacity: 1; transform: none; transition: none; }
-  .hero-grid { animation: none; }
-  .ticker { animation: none; }
-  .progress-bar { transition: none; }
   html { scroll-behavior: auto; }
 }
 
 /* Responsive */
 @media (max-width: 1024px) {
   .about-grid { grid-template-columns: 1fr; gap: 3rem; }
-  .skills-grid { gap: 2.5rem 3rem; }
+  .skills-grid { gap: 2rem 3rem; }
   .contact-inner { grid-template-columns: 1fr; gap: 2.5rem; }
   .contact-actions { flex-direction: row; flex-wrap: wrap; min-width: 0; }
 }
-
 @media (max-width: 768px) {
-  :root { --gap: 88px; }
+  :root { --gap: 80px; }
   .nav-links { display: none; }
   .projects-grid { grid-template-columns: 1fr; }
-  .skills-grid { grid-template-columns: 1fr; gap: 2rem; }
-  .hero-footer { display: none; }
-  .role-card { padding: 1.75rem; }
-  .role-idx { font-size: 2.4rem; }
+  .skills-grid { grid-template-columns: 1fr; gap: 1.75rem; }
+  .pp-features { grid-template-columns: 1fr 1fr; }
 }
-
 @media (max-width: 480px) {
-  :root { --gap: 68px; }
-  .nav, .hero-inner, .section { padding-left: 1.25rem; padding-right: 1.25rem; }
+  :root { --gap: 60px; }
+  .nav, .section { padding-left: 1.25rem; padding-right: 1.25rem; }
+  .hero-content { padding-left: 1.25rem; padding-right: 1.25rem; }
   .hero-ctas { flex-direction: column; }
   .stats-grid { grid-template-columns: 1fr; }
   .contact-actions { flex-direction: column; }
   .contact-inner { padding-top: 2.5rem; gap: 2rem; }
+  .pp-header { flex-direction: column; align-items: flex-start; gap: 1rem; }
+  .pp-features { grid-template-columns: 1fr; }
   .site-footer { padding-left: 1.25rem; padding-right: 1.25rem; }
 }


### PR DESCRIPTION
- Replace Playfair Display + Sora with Roboto + Roboto Mono throughout
- Remove decorative elements: hero background text, ticker strip, elaborate section number dividers, role card decorative indices
- Simplify section headers, hero layout, and stat cards
- Clean up animations (less stagger, simpler reveals)
- Add Personal Projects section (05) with TripForge card: description, feature highlights, tech stack, and GitHub link
- Renumber sections: skills to 06, contact to 07