### PR TITLE
Fix work photo layout and add WanderMate personal project

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,35 +130,39 @@
     <div class="timeline">
 
       <article class="role-card reveal-up">
-        <div class="role-head">
-          <div class="role-head-info">
-            <div class="role-period">2024 &ndash; Present</div>
-            <h3 class="role-title">Product Manager, Enterprise Data Products</h3>
-            <p class="role-company">TEAM Services Group</p>
-            <p class="role-context">National in-home healthcare platform &nbsp;·&nbsp; 15+ brands &nbsp;·&nbsp; 50 states</p>
+        <div class="role-card-layout">
+          <div class="role-card-content">
+            <div class="role-head">
+              <div class="role-head-info">
+                <div class="role-period">2024 &ndash; Present</div>
+                <h3 class="role-title">Product Manager, Enterprise Data Products</h3>
+                <p class="role-company">TEAM Services Group</p>
+                <p class="role-context">National in-home healthcare platform &nbsp;·&nbsp; 15+ brands &nbsp;·&nbsp; 50 states</p>
+              </div>
+            </div>
+            <ul class="role-highlights">
+              <li>Unified 16 organizations onto a single data platform, shipped 0 to 1 in under 6 months</li>
+              <li>$300K+ saved annually via AI-powered compliance document automation</li>
+              <li>End-to-end ownership across Snowflake, dbt, Dagster, Power BI, and Streamlit</li>
+              <li>120+ source systems integrated spanning payroll, operations, and clinical platforms</li>
+              <li>Cross-functional data team lead — drove Agile adoption and delivery predictability org-wide</li>
+              <li>Outcome-driven data roadmap delivered in partnership with executive leadership across 50 states</li>
+            </ul>
+            <div class="role-tags" aria-label="Tech stack">
+              <span class="tag">Snowflake</span>
+              <span class="tag">dbt</span>
+              <span class="tag">Dagster</span>
+              <span class="tag">Power BI</span>
+              <span class="tag">Streamlit</span>
+              <span class="tag">AWS</span>
+              <span class="tag">Python</span>
+              <span class="tag">SQL</span>
+              <span class="tag">GitHub</span>
+              <span class="tag">Jira</span>
+              <span class="tag">Figma</span>
+            </div>
           </div>
           <img src="assets/work.jpg" alt="Johnathan at work" class="role-photo" loading="lazy">
-        </div>
-        <ul class="role-highlights">
-          <li>Unified 16 organizations onto a single data platform, shipped 0 to 1 in under 6 months</li>
-          <li>$300K+ saved annually via AI-powered compliance document automation</li>
-          <li>End-to-end ownership across Snowflake, dbt, Dagster, Power BI, and Streamlit</li>
-          <li>120+ source systems integrated spanning payroll, operations, and clinical platforms</li>
-          <li>Cross-functional data team lead — drove Agile adoption and delivery predictability org-wide</li>
-          <li>Outcome-driven data roadmap delivered in partnership with executive leadership across 50 states</li>
-        </ul>
-        <div class="role-tags" aria-label="Tech stack">
-          <span class="tag">Snowflake</span>
-          <span class="tag">dbt</span>
-          <span class="tag">Dagster</span>
-          <span class="tag">Power BI</span>
-          <span class="tag">Streamlit</span>
-          <span class="tag">AWS</span>
-          <span class="tag">Python</span>
-          <span class="tag">SQL</span>
-          <span class="tag">GitHub</span>
-          <span class="tag">Jira</span>
-          <span class="tag">Figma</span>
         </div>
       </article>
 
@@ -316,6 +320,41 @@
         <span class="tag">Supabase</span>
         <span class="tag">Claude API</span>
         <span class="tag">Vercel</span>
+      </div>
+    </article>
+
+    <article class="personal-project-card reveal-up" style="--delay:0.08s">
+      <div class="pp-header">
+        <div class="pp-meta">
+          <span class="pp-status">In Development</span>
+          <h3 class="pp-title">WanderMate</h3>
+          <p class="pp-tagline">Outdoor adventure decision engine for Colorado, Wyoming &amp; Utah</p>
+        </div>
+        <a href="https://github.com/SpartanMods/wanderMate" target="_blank" rel="noopener noreferrer" class="pp-link" aria-label="WanderMate on GitHub">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+          View on GitHub
+        </a>
+      </div>
+      <p class="pp-desc">
+        An outdoor trip decision engine for campers, hikers, and anglers across Colorado, Wyoming, and Utah.
+        Enter your location, skill level, vehicle type, and crowd tolerance to get ranked, explained recommendations
+        drawn from 24 curated trip zones. A transparent 0–100 scoring algorithm weighs activity fit, drive time,
+        off-grid capability, and eight other dimensions — so you know exactly why a trip made the list.
+      </p>
+      <div class="pp-features">
+        <span>Weighted activity selection</span>
+        <span>Transparent 0–100 scoring</span>
+        <span>Top 3 comparison tool</span>
+        <span>Hidden-gem ranking</span>
+        <span>Skill &amp; vehicle matching</span>
+        <span>Surprise Me mode</span>
+      </div>
+      <div class="pp-tags">
+        <span class="tag">Next.js 14</span>
+        <span class="tag">TypeScript</span>
+        <span class="tag">React 18</span>
+        <span class="tag">Tailwind CSS</span>
+        <span class="tag">Zod</span>
       </div>
     </article>
   </section>

--- a/style.css
+++ b/style.css
@@ -290,16 +290,19 @@ ul { list-style: none; }
   box-shadow: 0 0 0 4px rgba(0,195,212,0.18);
 }
 .role-card:hover { border-color: var(--teal); background: var(--bg-surface-h); }
+.role-card-layout {
+  display: flex; gap: 1.5rem; align-items: stretch;
+}
+.role-card-content { flex: 1; min-width: 0; }
 .role-head {
-  display: flex; justify-content: space-between;
-  align-items: stretch; gap: 1.5rem; margin-bottom: 1.5rem;
+  display: flex;
+  align-items: flex-start; gap: 1.5rem; margin-bottom: 1.5rem;
 }
 .role-photo {
-  width: 220px; min-height: 180px;
+  width: 220px;
   object-fit: cover; object-position: center 20%;
   border-radius: var(--r); border: 1px solid var(--border);
   flex-shrink: 0; display: block;
-  align-self: stretch;
 }
 .role-title { font-size: 1.2rem; font-weight: 700; margin-bottom: 0.25rem; letter-spacing: 0.01em; }
 .role-company { font-size: 0.875rem; color: var(--teal); font-weight: 500; margin-bottom: 0.35rem; }
@@ -579,8 +582,8 @@ ul { list-style: none; }
   .projects-grid { grid-template-columns: 1fr; }
   .skills-grid { grid-template-columns: 1fr; gap: 1.75rem; }
   .pp-features { grid-template-columns: 1fr 1fr; }
-  .role-head { flex-direction: column; }
-  .role-photo { width: 100%; min-height: 0; height: 200px; object-position: center 25%; }
+  .role-card-layout { flex-direction: column; }
+  .role-photo { width: 100%; height: 200px; object-position: center 25%; }
   .timeline { padding-left: 1.75rem; }
   .role-card::before { left: calc(-1.75rem - 3px); }
 }


### PR DESCRIPTION
## Summary

- **Photo layout fix**: The work experience photo on the TEAM Services Group card now spans the full height of the card — sitting alongside the title, bullets, and tech tags — rather than only aligning with the header text. Achieved by wrapping card content in a `.role-card-layout` flex row and moving the photo out of `.role-head` to be a full-height side panel.
- **WanderMate project**: Added a second personal project card matching the TripForge pattern. WanderMate is an outdoor adventure decision engine for CO/WY/UT — built with Next.js 14, TypeScript, React 18, Tailwind CSS, and Zod.

## Test plan

- [ ] TEAM Services Group card: photo fills the full right side of the card (title + all 6 bullets + tags are alongside the photo, nothing pushed below)
- [ ] Procare and Seamless.AI cards (no photo): visually unchanged
- [ ] WanderMate card appears below TripForge in Personal Projects, styled consistently
- [ ] Mobile (≤ 768px): photo stacks above card content at full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)