### PR TITLE
Remove open-to-roles hero badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,6 @@
     <div class="hero-content">
       <div class="hero-text">
         <p class="hero-name reveal-up">Johnathan Margheret</p>
-        <span class="open-badge reveal-up" id="openBadge" style="--delay:0.04s" hidden>Open to senior and lead PM roles</span>
         <h1 class="hero-headline reveal-up" style="--delay:0.08s">
           Product leader who ships data, AI, and software products, and builds his own on the side.
         </h1>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,4 @@
-const OPEN_TO_WORK = true;
-
-// Show the "open to work" badge when the flag is on
-const openBadge = document.getElementById('openBadge');
-if (openBadge && OPEN_TO_WORK) openBadge.hidden = false;
+const OPEN_TO_WORK = false;
 
 // Theme toggle
 const root = document.documentElement;

--- a/style.css
+++ b/style.css
@@ -401,23 +401,6 @@ ul { list-style: none; }
 .project-card.c-mint  .proj-label { color: var(--mint); }
 .project-card.c-amber .proj-label { color: var(--amber); }
 
-/* Open to work badge */
-.open-badge {
-  display: inline-block; margin-bottom: 1rem;
-  padding: 0.3rem 0.7rem; border-radius: 999px;
-  font-family: var(--font-mono); font-size: 0.65rem;
-  letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--mint); border: 1px solid var(--mint);
-  background: rgba(0, 220, 171, 0.08);
-}
-.open-badge[hidden] { display: none; }
-.open-badge::before {
-  content: ''; display: inline-block;
-  width: 6px; height: 6px; border-radius: 50%;
-  background: var(--mint); margin-right: 0.45rem;
-  vertical-align: middle;
-}
-
 /* Personal project */
 .personal-project-card {
   background: var(--bg-surface);


### PR DESCRIPTION
Removes the "Open to senior and lead PM roles" badge from the hero. This change was made on the PR #8 branch but landed a moment after that PR was merged, so it never reached `main`. This PR applies it.

- Removes the badge `<span>` from `index.html`
- Reverts the `OPEN_TO_WORK` wiring in `main.js` back to `false` (its original state)
- Deletes the now-unused `.open-badge` CSS

https://claude.ai/code/session_01FhXxthHWaEE8uB8nBAQZMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhXxthHWaEE8uB8nBAQZMH)_