### PR TITLE
Update hero tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       <div class="hero-text">
         <p class="hero-name reveal-up">Johnathan Margheret</p>
         <h1 class="hero-headline reveal-up" style="--delay:0.08s">
-          Product leader who ships data, AI, and software products, and builds his own on the side.
+          Product leader shipping data, AI and software products while building on the side.
         </h1>
         <p class="hero-sub reveal-up" style="--delay:0.16s">
           Six years turning ambiguous, regulated problems into products people actually use, across B2B SaaS and enterprise data platforms.


### PR DESCRIPTION
Updates the hero headline.

Before: "Product leader who ships data, AI, and software products, and builds his own on the side."
After: "Product leader shipping data, AI and software products while building on the side."

https://claude.ai/code/session_01FhXxthHWaEE8uB8nBAQZMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhXxthHWaEE8uB8nBAQZMH)_