### PR TITLE
Add custom domain www.johnathanmargheret.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.johnathanmargheret.com

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Johnathan Margheret is a product leader who ships data, AI, and software products. Six years across B2B SaaS, enterprise data platforms, and regulated healthcare.">
   <title>Johnathan Margheret - Product Leader</title>
-  <link rel="canonical" href="https://spartanmods.github.io/">
+  <link rel="canonical" href="https://www.johnathanmargheret.com/">
 
   <!-- Favicon: small JM mark, no extra request -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%231a1a1a'/><text x='16' y='22' font-family='Arial,sans-serif' font-size='15' font-weight='700' fill='%2300c3d4' text-anchor='middle'>JM</text></svg>">
@@ -14,14 +14,14 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="Johnathan Margheret - Product Leader">
   <meta property="og:description" content="A product leader who ships data, AI, and software products, and builds his own.">
-  <meta property="og:url" content="https://spartanmods.github.io/">
-  <meta property="og:image" content="https://spartanmods.github.io/assets/og-image.jpg">
+  <meta property="og:url" content="https://www.johnathanmargheret.com/">
+  <meta property="og:image" content="https://www.johnathanmargheret.com/assets/og-image.jpg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Johnathan Margheret - Product Leader">
   <meta name="twitter:description" content="A product leader who ships data, AI, and software products, and builds his own.">
-  <meta name="twitter:image" content="https://spartanmods.github.io/assets/og-image.jpg">
+  <meta name="twitter:image" content="https://www.johnathanmargheret.com/assets/og-image.jpg">
 
   <script type="application/ld+json">
   {
@@ -29,8 +29,8 @@
     "@type": "Person",
     "name": "Johnathan Margheret",
     "jobTitle": "Product Manager",
-    "url": "https://spartanmods.github.io/",
-    "image": "https://spartanmods.github.io/assets/og-image.jpg",
+    "url": "https://www.johnathanmargheret.com/",
+    "image": "https://www.johnathanmargheret.com/assets/og-image.jpg",
     "worksFor": { "@type": "Organization", "name": "TEAM Services Group" },
     "address": { "@type": "PostalAddress", "addressLocality": "Denver", "addressRegion": "CO" },
     "sameAs": [


### PR DESCRIPTION
Sets up `www.johnathanmargheret.com` as the custom domain.

**Repo changes:**
- Adds `CNAME` file containing `www.johnathanmargheret.com` (tells GitHub Pages which domain to serve)
- Updates all 6 hardcoded `spartanmods.github.io` URLs in `index.html` to `https://www.johnathanmargheret.com/` (canonical, og:url, og:image, twitter:image, JSON-LD url + image)

**DNS changes needed at your registrar (not in this PR):**

| Type | Host | Value |
|------|------|-------|
| CNAME | `www` | `spartanmods.github.io` |
| A | `@` | `185.199.108.153` |
| A | `@` | `185.199.109.153` |
| A | `@` | `185.199.110.153` |
| A | `@` | `185.199.111.153` |
| AAAA | `@` | `2606:50c0:8000::153` |
| AAAA | `@` | `2606:50c0:8001::153` |
| AAAA | `@` | `2606:50c0:8002::153` |
| AAAA | `@` | `2606:50c0:8003::153` |

**GitHub repo settings (after DNS propagates):**
Go to **Settings → Pages → Custom domain**, enter `www.johnathanmargheret.com`, save, wait for the TLS cert, then tick **Enforce HTTPS**.

https://claude.ai/code/session_01FhXxthHWaEE8uB8nBAQZMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhXxthHWaEE8uB8nBAQZMH)_